### PR TITLE
Increase KubeSpawner.http_timeout for jupyterhub

### DIFF
--- a/terraform/modules/jupyterhub/main.tf
+++ b/terraform/modules/jupyterhub/main.tf
@@ -145,6 +145,9 @@ resource "helm_release" "jupyterhub" {
             storageClassName: "${var.default_storage_class}"
         networkPolicy:
           enabled: false
+        extraConfig:
+          myConfig.py: |
+            c.KubeSpawner.http_timeout = int(180)
       singleuser:
         # https://zero-to-jupyterhub.readthedocs.io/en/latest/jupyterhub/customizing/user-environment.html#use-jupyterlab-by-default
         defaultUrl: /lab


### PR DESCRIPTION
Our Jupyter sessions, when running for the first time, need lots of IO to copy initial Conda environments, which may take longer on some configurations. 