### PR TITLE
Use new machine_type; use Ubuntu image for GKE

### DIFF
--- a/terraform/gcp/modules/icl-cluster/main.tf
+++ b/terraform/gcp/modules/icl-cluster/main.tf
@@ -3,7 +3,8 @@ resource "google_container_cluster" "cluster" {
   # count per zone
   initial_node_count = 1
   node_config {
-    machine_type = "e2-standard-4"
+    machine_type = var.machine_type
+    image_type = "UBUNTU_CONTAINERD"
   }
   deletion_protection = false
   node_version = var.node_version


### PR DESCRIPTION
> By default, Google GKE configures nodes with the Container-Optimized OS with Containerd from Google. This operating system is not supported by the Operator.

> To use a supported operating system, such as Ubuntu 22.04 or 20.04, configure your GKE cluster entirely with Ubuntu containerd nodes images or with a node pool that uses Ubuntu containerd node images.

