### PR TITLE
kubernetes-dashboard: disable skip-login and insecure-login

### DIFF
--- a/scripts/deploy/aws.sh
+++ b/scripts/deploy/aws.sh
@@ -167,6 +167,11 @@ if [[ " $@ " =~ " --start-proxy " ]]; then
   exit 0
 fi
 
+if [[ " $1 " =~ " --get-admin-token " ]]; then
+  get_admin_token
+  exit $?
+fi
+
 if [[ " $@ " =~ " --stop-proxy " ]]; then
   stop_proxy
   exit 0
@@ -177,3 +182,4 @@ render_workspace
 deploy_eks
 update_config
 deploy_x1
+get_admin_token

--- a/scripts/deploy/functions.sh
+++ b/scripts/deploy/functions.sh
@@ -12,6 +12,13 @@ function proxy_container_status() {
   docker container inspect --format '{{.State.Status}}' icl-proxy 2>/dev/null || echo ""
 }
 
+function get_admin_token()
+{
+  echo "Kubernetes Dashboard: https://dashboard.${ICL_INGRESS_DOMAIN}"
+  echo "Cluster token for admin-user:"
+  kubectl -n kubernetes-dashboard create token admin-user
+}
+
 function warn_about_proxy_and_variables()
 {
   proxy_variables_used=0

--- a/scripts/deploy/functions.sh
+++ b/scripts/deploy/functions.sh
@@ -16,7 +16,7 @@ function get_admin_token()
 {
   echo "Kubernetes Dashboard: https://dashboard.${ICL_INGRESS_DOMAIN}"
   echo "Cluster token for admin-user:"
-  kubectl -n kubernetes-dashboard create token admin-user
+  control_node kubectl -n kubernetes-dashboard create token admin-user
 }
 
 function warn_about_proxy_and_variables()

--- a/scripts/deploy/gke.sh
+++ b/scripts/deploy/gke.sh
@@ -252,6 +252,11 @@ if [[ " $@ " =~ " --print-workspace " ]]; then
   exit $?
 fi
 
+if [[ " $1 " =~ " --get-admin-token " ]]; then
+  get_admin_token
+  exit $?
+fi
+
 if [[ " $1 " =~ " --console " ]]; then
   shift
   _rest_args="$@"
@@ -270,3 +275,4 @@ render_workspace
 deploy_gke
 update_config
 deploy_x1
+get_admin_token

--- a/scripts/deploy/kind.sh
+++ b/scripts/deploy/kind.sh
@@ -313,4 +313,8 @@ with_corefile
 control_node "terraform -chdir=terraform/icl init -upgrade -input=false"
 control_node "terraform -chdir=terraform/icl apply -input=false -auto-approve ${terraform_extra_args[*]}"
 
+echo
+get_admin_token
+echo
+
 echo "To delete the cluster run '$0 --delete'"

--- a/terraform/modules/kubernetes-dashboard/main.tf
+++ b/terraform/modules/kubernetes-dashboard/main.tf
@@ -9,8 +9,6 @@ resource "helm_release" "kubernetes-dashboard" {
     <<-EOT
       protocolHttp: true
       extraArgs:
-        - --enable-insecure-login
-        - --enable-skip-login
         - --disable-settings-authorizer
       service:
         type: ClusterIP

--- a/terraform/modules/kubernetes-dashboard/main.tf
+++ b/terraform/modules/kubernetes-dashboard/main.tf
@@ -9,7 +9,7 @@ resource "helm_release" "kubernetes-dashboard" {
     <<-EOT
       protocolHttp: true
       extraArgs:
-        - --enable-insecure-login
+        - --enable-insecure-login=false
       service:
         type: ClusterIP
       ingress:

--- a/terraform/modules/kubernetes-dashboard/main.tf
+++ b/terraform/modules/kubernetes-dashboard/main.tf
@@ -9,7 +9,7 @@ resource "helm_release" "kubernetes-dashboard" {
     <<-EOT
       protocolHttp: true
       extraArgs:
-        - --disable-settings-authorizer
+        - --enable-insecure-login
       service:
         type: ClusterIP
       ingress:

--- a/terraform/modules/kubernetes-dashboard/variables.tf
+++ b/terraform/modules/kubernetes-dashboard/variables.tf
@@ -1,6 +1,6 @@
 variable "release" {
   description = "Version of kubernetes-dashboard Helm chart"
-  default = "5.7.0"
+  default = "6.0.8"
   type = string
 }
 


### PR DESCRIPTION
Users are now required to authenticate by token.
New `--get-admin-token` argument is added for `gke.sh`, `aws.sh`.
Now, for the user guidance, deploy scripts will print token and dashboard URL at the last step:
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Kubernetes Dashboard: https://dashboard.example.com
Cluster token for admin-user:
eyJhbGciOiJSxxxxxxxxxxxx....
```