### PR TITLE
SSH for GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ terraform/**/terraform.tfstate*
 logs/
 misc/
 build/
+venv/
 
 # Ignore files created by Prefect in unit tests
 .prefectignore

--- a/scripts/deploy/gke.sh
+++ b/scripts/deploy/gke.sh
@@ -91,6 +91,7 @@ function x1_terraform_args() {
     -var ray_load_balancer_enabled=false
     -var externaldns_enabled="${X1_EXTERNALDNS_ENABLED}"
     -var use_node_ip_for_user_ports=true
+    -var use_external_node_ip_for_user_ports=true
   )
   if [[ -v X1_TERRAFORM_DISABLE_LOCKING ]]; then
     terraform_extra_args+=( -lock=false )

--- a/scripts/deploy/gke.sh
+++ b/scripts/deploy/gke.sh
@@ -90,6 +90,7 @@ function x1_terraform_args() {
     -var default_storage_class="standard-rwo"
     -var ray_load_balancer_enabled=false
     -var externaldns_enabled="${X1_EXTERNALDNS_ENABLED}"
+    -var use_node_ip_for_user_ports=true
   )
   if [[ -v X1_TERRAFORM_DISABLE_LOCKING ]]; then
     terraform_extra_args+=( -lock=false )

--- a/src/infractl/hub/jupyterhub.py
+++ b/src/infractl/hub/jupyterhub.py
@@ -165,7 +165,7 @@ def get_node_ip(name: str, external: bool = False) -> str:
     """Returns node IP address."""
     response = kube.api().core_v1().read_node_status(name)
     for address in response.status.addresses:
-        if address.type == 'ExternalIP' and external == True:
+        if address.type == 'ExternalIP' and external is True:
             return address.address
         if address.type == 'InternalIP':
             return address.address
@@ -384,7 +384,11 @@ def enable_ssh(username: str, key: Optional[str] = None) -> str:
     use_external_node_ip_for_user_ports = config.get().get('use_external_node_ip_for_user_ports')
     ingress_domain = config.get().get('ingress_domain')
     print('ingress_domain', ingress_domain)
-    ssh_host = get_node_ip(pod.spec.node_name, external=use_external_node_ip_for_user_ports) if use_node_ip_for_user_ports else ingress_domain
+    ssh_host = (
+        get_node_ip(pod.spec.node_name, external=use_external_node_ip_for_user_ports)
+        if use_node_ip_for_user_ports
+        else ingress_domain
+    )
     ssh_args = f'jovyan@{ssh_host} -p {response.spec.ports[0].node_port}'
     if jumphost:
         return f'ssh -J {jumphost} {ssh_args}'

--- a/src/infractl/hub/jupyterhub.py
+++ b/src/infractl/hub/jupyterhub.py
@@ -163,13 +163,18 @@ def get_hub_pod(namespace: str) -> client.V1Pod:
 
 def get_node_ip(name: str, external: bool = False) -> str:
     """Returns node IP address."""
+    external_ip = None
+    internal_ip = None
+
     response = kube.api().core_v1().read_node_status(name)
     for address in response.status.addresses:
-        if address.type == 'ExternalIP' and external is True:
-            return address.address
+        if address.type == 'ExternalIP':
+            external_ip = address.address
         if address.type == 'InternalIP':
-            return address.address
-    return name
+            internal_ip = address.address
+    if external_ip and external:
+        return external_ip
+    return internal_ip or name
 
 
 def get_user_id(username: str) -> str:

--- a/src/infractl/hub/jupyterhub.py
+++ b/src/infractl/hub/jupyterhub.py
@@ -378,9 +378,10 @@ def enable_ssh(username: str, key: Optional[str] = None) -> str:
             if error.status != 404:
                 raise error
 
-    ssh_proxy = config.get().get('ingress_domain')
+    use_node_ip_for_user_ports = config.get().get('use_node_ip_for_user_ports')
+    ingress_domain = config.get().get('use_node_ip_for_ssh')
     print('ingress_domain', ssh_proxy)
-    ssh_host = ssh_proxy or get_node_ip(pod.spec.node_name)
+    ssh_host = get_node_ip(pod.spec.node_name) if use_node_ip_for_user_ports else ingress_domain
     ssh_args = f'jovyan@{ssh_host} -p {response.spec.ports[0].node_port}'
     if jumphost:
         return f'ssh -J {jumphost} {ssh_args}'

--- a/src/infractl/hub/jupyterhub.py
+++ b/src/infractl/hub/jupyterhub.py
@@ -379,7 +379,7 @@ def enable_ssh(username: str, key: Optional[str] = None) -> str:
                 raise error
 
     use_node_ip_for_user_ports = config.get().get('use_node_ip_for_user_ports')
-    ingress_domain = config.get().get('use_node_ip_for_ssh')
+    ingress_domain = config.get().get('ingress_domain')
     print('ingress_domain', ssh_proxy)
     ssh_host = get_node_ip(pod.spec.node_name) if use_node_ip_for_user_ports else ingress_domain
     ssh_args = f'jovyan@{ssh_host} -p {response.spec.ports[0].node_port}'

--- a/src/infractl/hub/jupyterhub.py
+++ b/src/infractl/hub/jupyterhub.py
@@ -380,7 +380,7 @@ def enable_ssh(username: str, key: Optional[str] = None) -> str:
 
     use_node_ip_for_user_ports = config.get().get('use_node_ip_for_user_ports')
     ingress_domain = config.get().get('ingress_domain')
-    print('ingress_domain', ssh_proxy)
+    print('ingress_domain', ingress_domain)
     ssh_host = get_node_ip(pod.spec.node_name) if use_node_ip_for_user_ports else ingress_domain
     ssh_args = f'jovyan@{ssh_host} -p {response.spec.ports[0].node_port}'
     if jumphost:

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -27,3 +27,10 @@ module "firewall-rule-allow-tcp-8443" {
   cluster_name = var.cluster_name
   network = module.icl-cluster.network
 }
+
+module "firewall-rule-allow-user-ports" {
+  depends_on = [ module.icl-cluster ]
+  source = "./modules/firewall-rule-allow-user-ports"
+  cluster_name = var.cluster_name
+  network = module.icl-cluster.network
+}

--- a/terraform/gcp/modules/firewall-rule-allow-user-ports/main.tf
+++ b/terraform/gcp/modules/firewall-rule-allow-user-ports/main.tf
@@ -1,0 +1,10 @@
+resource "google_compute_firewall" "allow-user-ports" {
+  name = "allow-user-ports-${var.cluster_name}"
+  network = var.network
+  allow {
+    protocol = "tcp"
+    ports = ["32000-34000"]
+  }
+  source_ranges = [ "0.0.0.0/0" ]
+}
+

--- a/terraform/gcp/modules/firewall-rule-allow-user-ports/variables.tf
+++ b/terraform/gcp/modules/firewall-rule-allow-user-ports/variables.tf
@@ -1,0 +1,6 @@
+variable "cluster_name" {
+  description = "Name of GKE cluster"
+  type = string
+}
+
+variable "network" {}

--- a/terraform/icl/main.tf
+++ b/terraform/icl/main.tf
@@ -188,4 +188,5 @@ module "icl-hub" {
   source = "../modules/icl-hub"
   namespace_labels = var.namespace_labels
   ingress_domain = var.ingress_domain
+  use_node_ip_for_user_ports = var.use_node_ip_for_user_ports
 }

--- a/terraform/icl/main.tf
+++ b/terraform/icl/main.tf
@@ -189,4 +189,5 @@ module "icl-hub" {
   namespace_labels = var.namespace_labels
   ingress_domain = var.ingress_domain
   use_node_ip_for_user_ports = var.use_node_ip_for_user_ports
+  use_external_node_ip_for_user_ports = var.use_external_node_ip_for_user_ports
 }

--- a/terraform/icl/variables.tf
+++ b/terraform/icl/variables.tf
@@ -280,3 +280,9 @@ variable "intel_gpu_enabled" {
   type = bool
   default = false
 }
+
+variable "use_node_ip_for_user_ports" {
+  description = "Use k8s node's IP address when exposing user ports"
+  type = bool 
+  default = false
+}

--- a/terraform/icl/variables.tf
+++ b/terraform/icl/variables.tf
@@ -282,7 +282,13 @@ variable "intel_gpu_enabled" {
 }
 
 variable "use_node_ip_for_user_ports" {
-  description = "Use k8s node's IP address when exposing user ports"
+  description = "Use k8s Node's InternalIP address when exposing user ports"
   type = bool 
+  default = false
+}
+
+variable "use_external_node_ip_for_user_ports" {
+  description = "Use k8s Node's ExternalIP address when exposing user ports (use with use_node_ip_for_user_ports)"
+  type = bool
   default = false
 }

--- a/terraform/modules/icl-hub/main.tf
+++ b/terraform/modules/icl-hub/main.tf
@@ -17,6 +17,7 @@ resource "kubernetes_config_map" "config" {
     "hub.toml" = <<-EOF
       ingress_domain = "${var.ingress_domain}"
       use_node_ip_for_user_ports = "${var.use_node_ip_for_user_ports}"
+      use_external_node_ip_for_user_ports = "${var.use_external_node_ip_for_user_ports}"
     EOF
   }
 }
@@ -45,7 +46,7 @@ resource "kubernetes_deployment" "icl-hub" {
       spec {
         container {
           name = "icl-hub"
-          image = "pbchekin/icl-hub:0.0.3"
+          image = "docker.io/kwasd/icl-hub:0.0.4b1"
           command = [
             "python", "-m", "infractl.hub.main", "server", "start"
           ]

--- a/terraform/modules/icl-hub/main.tf
+++ b/terraform/modules/icl-hub/main.tf
@@ -46,7 +46,7 @@ resource "kubernetes_deployment" "icl-hub" {
       spec {
         container {
           name = "icl-hub"
-          image = "kwasd/icl-hub:0.0.4"
+          image = "pbchekin/icl-hub:0.0.4"
           command = [
             "python", "-m", "infractl.hub.main", "server", "start"
           ]

--- a/terraform/modules/icl-hub/main.tf
+++ b/terraform/modules/icl-hub/main.tf
@@ -16,8 +16,8 @@ resource "kubernetes_config_map" "config" {
   data = {
     "hub.toml" = <<-EOF
       ingress_domain = "${var.ingress_domain}"
-      use_node_ip_for_user_ports = "${var.use_node_ip_for_user_ports}"
-      use_external_node_ip_for_user_ports = "${var.use_external_node_ip_for_user_ports}"
+      use_node_ip_for_user_ports = ${var.use_node_ip_for_user_ports}
+      use_external_node_ip_for_user_ports = ${var.use_external_node_ip_for_user_ports}
     EOF
   }
 }
@@ -46,7 +46,7 @@ resource "kubernetes_deployment" "icl-hub" {
       spec {
         container {
           name = "icl-hub"
-          image = "docker.io/kwasd/icl-hub:0.0.4b1"
+          image = "kwasd/icl-hub:0.0.4"
           command = [
             "python", "-m", "infractl.hub.main", "server", "start"
           ]

--- a/terraform/modules/icl-hub/main.tf
+++ b/terraform/modules/icl-hub/main.tf
@@ -16,6 +16,7 @@ resource "kubernetes_config_map" "config" {
   data = {
     "hub.toml" = <<-EOF
       ingress_domain = "${var.ingress_domain}"
+      use_node_ip_for_user_ports = "${var.use_node_ip_for_user_ports}"
     EOF
   }
 }

--- a/terraform/modules/icl-hub/variables.tf
+++ b/terraform/modules/icl-hub/variables.tf
@@ -10,6 +10,11 @@ variable "ingress_domain" {
 }
 
 variable "use_node_ip_for_user_ports" {
-  description = "Use k8s node's IP address when exposing user ports"
+  description = "Use k8s Node's IP address when exposing user ports"
+  type = bool
+}
+
+variable "use_external_node_ip_for_user_ports" {
+  description = "Use k8s Node's ExternalIP address when exposing user ports (use with use_node_ip_for_user_ports)"
   type = bool
 }

--- a/terraform/modules/icl-hub/variables.tf
+++ b/terraform/modules/icl-hub/variables.tf
@@ -11,5 +11,5 @@ variable "ingress_domain" {
 
 variable "use_node_ip_for_user_ports" {
   description = "Use k8s node's IP address when exposing user ports"
-  type = bool 
+  type = bool
 }

--- a/terraform/modules/icl-hub/variables.tf
+++ b/terraform/modules/icl-hub/variables.tf
@@ -8,3 +8,8 @@ variable "ingress_domain" {
   description = "Ingress domain name"
   type = string
 }
+
+variable "use_node_ip_for_user_ports" {
+  description = "Use k8s node's IP address when exposing user ports"
+  type = bool 
+}


### PR DESCRIPTION
1. Open TCP 32000-34000 with a new `allow-user-ports` firewall rule.
2. Add a new icl-hub configuration parameters `use_node_ip_for_user_ports` and `use_external_node_ip_for_user_ports` to handle output or behavior when direct network access to cluster nodes is possible.

Example output:
For `use_node_ip_for_user_ports=false`:
`Use the following command to log in to your session: ssh user@example.com -p 32001`

For `use_node_ip_for_user_ports=true` and `use_external_node_ip_for_user_ports=false`:
`Use the following command to log in to your session: ssh user@10.0.0.1 -p 32001`

For `use_node_ip_for_user_ports=true` and `use_external_node_ip_for_user_ports=true`:
`Use the following command to log in to your session: ssh user@1.2.3.4 -p 32001`