### PR TITLE
[aws][gcp]: Fix port range, use ExternalIP for user ports in AWS

### DIFF
--- a/scripts/deploy/aws.sh
+++ b/scripts/deploy/aws.sh
@@ -67,6 +67,8 @@ function x1_terraform_args() {
     -var default_storage_class="gp2"
     -var externaldns_enabled="${X1_EXTERNALDNS_ENABLED}"
     -var ray_load_balancer_enabled=true # dedicated AWS CLB for Ray client endpoint on port 80
+    -var use_node_ip_for_user_ports=true
+    -var use_external_node_ip_for_user_ports=true
   )
   echo "${terraform_extra_args[*]}"
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -20,13 +20,24 @@ module "eks" {
       type = "ingress"
       self = true
     }
-    user_ports_incoming = {
+    user_ports_incoming_node = {
       description = "Incoming TCP to user ports"
       protocol = "tcp"
       from_port = 32001
       to_port = 33999
       type = "ingress"
-      self = false
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  cluster_security_group_additional_rules = {
+    user_ports_incoming_cluster = {
+      description = "Incoming TCP to user ports"
+      protocol = "tcp"
+      from_port = 32001
+      to_port = 33999
+      type = "ingress"
+      cidr_blocks = ["0.0.0.0/0"]
     }
   }
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -26,7 +26,7 @@ module "eks" {
       from_port = 32001
       to_port = 33999
       type = "ingress"
-      self = true
+      self = false
     }
   }
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -20,6 +20,14 @@ module "eks" {
       type = "ingress"
       self = true
     }
+    user_ports_incoming = {
+      description = "Incoming TCP to user ports"
+      protocol = "tcp"
+      from_port = 32001
+      to_port = 33999
+      type = "ingress"
+      self = true
+    }
   }
 
   cluster_addons = {

--- a/terraform/gcp/modules/firewall-rule-allow-user-ports/main.tf
+++ b/terraform/gcp/modules/firewall-rule-allow-user-ports/main.tf
@@ -3,7 +3,7 @@ resource "google_compute_firewall" "allow-user-ports" {
   network = var.network
   allow {
     protocol = "tcp"
-    ports = ["32000-34000"]
+    ports = ["32001-33999"]
   }
   source_ranges = [ "0.0.0.0/0" ]
 }


### PR DESCRIPTION
Since nodes have ExternalIP, use it for AWS by default.
Fix port range to exclude first and last ports from the range.
