### PR TITLE
Pass `buildargs` to docker in remote builder

### DIFF
--- a/src/infractl/docker/prefect/builder.py
+++ b/src/infractl/docker/prefect/builder.py
@@ -107,8 +107,14 @@ def build(build_args: Dict[str, Any], registry: str):
     try:
         wait_docker()
 
+        cmd = ['docker', 'build', '--tag', full_tag, 'context']
+        buildargs = build_args.get('buildargs')
+        if buildargs:
+            for name, value in buildargs.items():
+                cmd.append('--build-arg')
+                cmd.append(f'{name}={value}')
         with subprocess.Popen(
-            ['docker', 'build', '--tag', full_tag, 'context'],
+            cmd,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
         ) as process:
@@ -118,8 +124,9 @@ def build(build_args: Dict[str, Any], registry: str):
             if process.returncode != 0:
                 raise BuildError('Build failed')
 
+        cmd = ['docker', 'push', full_tag]
         with subprocess.Popen(
-            ['docker', 'push', full_tag],
+            cmd,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
         ) as process:

--- a/tests/integration/test_infractl_docker.py
+++ b/tests/integration/test_infractl_docker.py
@@ -37,7 +37,7 @@ def test_local_builder(tmp_path: pathlib.Path, address):
     image = builder.build(
         path=str(tmp_path),
         tag=tag,
-        buildargs ={
+        buildargs={
             'TEST_FILE': 'test_file',
         },
     )

--- a/tests/integration/test_infractl_docker.py
+++ b/tests/integration/test_infractl_docker.py
@@ -11,7 +11,10 @@ from infractl import docker
 DOCKERFILE = """
 FROM scratch
 
-COPY test_file .
+# This argument needs to be set by the builder, otherwise the test will fail 
+ARG TEST_FILE=no_such_file
+
+COPY $TEST_FILE .
 """
 
 
@@ -34,6 +37,9 @@ def test_local_builder(tmp_path: pathlib.Path, address):
     image = builder.build(
         path=str(tmp_path),
         tag=tag,
+        buildargs ={
+            'TEST_FILE': 'test_file',
+        },
     )
 
     assert image.full_name == tag
@@ -57,6 +63,9 @@ def test_remote_builder(tmp_path: pathlib.Path, address):
     image = builder.build(
         path=str(tmp_path),
         tag=tag,
+        buildargs={
+            'TEST_FILE': 'test_file',
+        },
     )
 
     assert image.full_name == tag


### PR DESCRIPTION
Previously `buildargs` were ignored.