### PR TITLE
Custom /dev/shm size for JupyterHub

### DIFF
--- a/terraform/icl/main.tf
+++ b/terraform/icl/main.tf
@@ -115,6 +115,7 @@ module "jupyterhub" {
   jupyterhub_singleuser_volume_size = var.jupyterhub_singleuser_volume_size
   jupyterhub_singleuser_default_image = var.jupyterhub_singleuser_default_image
   jupyterhub_gpu_profile_enabled = var.intel_gpu_enabled
+  jupyterhub_shared_memory_size = var.jupyterhub_shared_memory_size
   jupyterhub_gpu_profile_image = var.jupyterhub_gpu_profile_image
   jupyterhub_cluster_admin_enabled = var.jupyterhub_cluster_admin_enabled
   ingress_domain = var.ingress_domain

--- a/terraform/icl/variables.tf
+++ b/terraform/icl/variables.tf
@@ -221,6 +221,12 @@ variable "jupyterhub_cluster_admin_enabled" {
   default = false
 }
 
+variable "jupyterhub_shared_memory_size" {
+  description = "Custom size of /dev/shm, empty for default"
+  type = string
+  default = ""
+}
+
 variable "olm_enabled" {
   description = "Enable Operator Lifecycle Manager, see https://operatorhub.io/how-to-install-an-operator"
   type = bool

--- a/terraform/modules/jupyterhub/main.tf
+++ b/terraform/modules/jupyterhub/main.tf
@@ -70,21 +70,40 @@ locals {
       storageClass = var.default_storage_class
     }
 
-    extraVolumes = !var.shared_volume_enabled ? [] : [
-      {
-        name = "data"
-        persistentVolumeClaim = {
-          claimName = module.shared-volume.0.claim_name
+    extraVolumes = concat(
+      !var.shared_volume_enabled ? [] : [
+        {
+          name = "data"
+          persistentVolumeClaim = {
+            claimName = module.shared-volume.0.claim_name
+          }
         }
-      }
-    ]
+      ],
+      var.jupyterhub_shared_memory_size == "" ? [] : [
+        {
+          name = "shared-mem"
+          emptyDir = {
+            medium = "Memory"
+            sizeLimit = "1Gi"
+          }
+        }
+      ],
+    )
 
-    extraVolumeMounts = !var.shared_volume_enabled ? [] : [
-      {
-        mountPath = "/data"
-        name = "data"
-      }
-    ]
+    extraVolumeMounts = concat(
+      !var.shared_volume_enabled ? [] : [
+        {
+          mountPath = "/data"
+          name = "data"
+        }
+      ],
+      var.jupyterhub_shared_memory_size == "" ? [] : [
+        {
+          mountPath = "/dev/shm"
+          name = "shared-mem"
+        }
+      ]
+    )
   }
 
   # https://z2jh.jupyter.org/en/latest/resources/reference.html#singleuser-extrafiles

--- a/terraform/modules/jupyterhub/variables.tf
+++ b/terraform/modules/jupyterhub/variables.tf
@@ -36,6 +36,12 @@ variable "jupyterhub_gpu_profile_image" {
   default = ""
 }
 
+variable "jupyterhub_shared_memory_size" {
+  description = "Custom size of /dev/shm, empty for default"
+  type = string
+  default = ""
+}
+
 variable "prefect_api_url" {
   description = "Prefect API URL"
   type = string


### PR DESCRIPTION
If `jupyterhub_shared_memory_size` is not set, then the standard /dev/shm (65M) will be used for each JupyterHub session. Otherwise the value, for example, "1Gi" will be used for /dev/shm size.

Looks like JupyterHub does not allow setting custom volumes per profile, so the new parameter is for all profiles.