### PR TITLE
Custom JupyterHub profiles as Terraform variable

### DIFF
--- a/terraform/icl/main.tf
+++ b/terraform/icl/main.tf
@@ -118,6 +118,7 @@ module "jupyterhub" {
   jupyterhub_shared_memory_size = var.jupyterhub_shared_memory_size
   jupyterhub_gpu_profile_image = var.jupyterhub_gpu_profile_image
   jupyterhub_cluster_admin_enabled = var.jupyterhub_cluster_admin_enabled
+  jupyterhub_profiles = var.jupyterhub_profiles
   ingress_domain = var.ingress_domain
   shared_volume_enabled = var.shared_volume_enabled
 }

--- a/terraform/icl/variables.tf
+++ b/terraform/icl/variables.tf
@@ -227,6 +227,12 @@ variable "jupyterhub_shared_memory_size" {
   default = ""
 }
 
+variable "jupyterhub_profiles" {
+  description = "Additional JupyterHub profiles"
+  type = list(any)
+  default = []
+}
+
 variable "olm_enabled" {
   description = "Enable Operator Lifecycle Manager, see https://operatorhub.io/how-to-install-an-operator"
   type = bool

--- a/terraform/modules/jupyterhub/main.tf
+++ b/terraform/modules/jupyterhub/main.tf
@@ -61,6 +61,7 @@ locals {
     ],
     var.jupyterhub_gpu_profile_enabled ? [local.jupyterhub_gpu_profile] : [],
     var.jupyterhub_gpu_profile_enabled ? [local.jupyterhub_gpu_admin_profile] : [],
+    var.jupyterhub_profiles,
   )
 
   jupyterhub_storage = {

--- a/terraform/modules/jupyterhub/variables.tf
+++ b/terraform/modules/jupyterhub/variables.tf
@@ -65,3 +65,9 @@ variable "jupyterhub_cluster_admin_enabled" {
   type = bool
   default = false
 }
+
+variable "jupyterhub_profiles" {
+  description = "Additional JupyterHub profiles"
+  type = list(any)
+  default = []
+}


### PR DESCRIPTION
Adding new Terraform variable `jupyterhub_profiles` that allows defining additional profiles as a list of maps. Example:

```
jupyterhub_profiles = [
  {
    display_name = "Triton (GPU, oneAPI Base Toolkit 2024.0.1)"
    description = "Triton development environment with GPU"
    kubespawner_override = {
      image = "pbchekin/icl-jupyterhub-triton:0.0.19"
      # required for sudo
      allow_privilege_escalation = true
      extra_resource_limits = {
        "gpu.intel.com/i915" = "1"
      }
    }
  }
]
```