### PR TITLE
Fix CI kubespray workflow

### DIFF
--- a/scripts/ccn/everything.sh
+++ b/scripts/ccn/everything.sh
@@ -12,7 +12,7 @@ cd ~/kubespray
 ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml --become cluster.yml
 
 cd ~/x1
-ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml ansible/playbooks/fetch-kubeconfig.yaml
+ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml ansible/playbooks/fetch-kubeconfig.yaml || sleep 60m
 ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml ansible/playbooks/terraform_tfvars.yaml
 
 cd ~/x1/terraform/icl

--- a/scripts/ccn/everything.sh
+++ b/scripts/ccn/everything.sh
@@ -12,7 +12,7 @@ cd ~/kubespray
 ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml --become cluster.yml
 
 cd ~/x1
-ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml ansible/playbooks/fetch-kubeconfig.yaml || sleep 60m
+ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml ansible/playbooks/fetch-kubeconfig.yaml
 ansible-playbook --inventory ~/generated/kubespray-inventory/inventory.yaml ansible/playbooks/terraform_tfvars.yaml
 
 cd ~/x1/terraform/icl

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -16,6 +16,7 @@ vm_exec ./everything.sh
 RESULT=0
 if ! vm_exec ./test.sh; then
   RESULT=1
+  sleep 60m
 fi
 
 vm_copy_logs

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -10,15 +10,16 @@ export no_proxy=${X1_NOMAAS_CLUSTER_SUBNET_PREFIX}.0/24,$no_proxy
 echo X1_LIBVIRT_DEFAULT_PREFIX: $X1_LIBVIRT_DEFAULT_PREFIX
 echo X1_NOMAAS_CLUSTER_SUBNET_PREFIX: $X1_NOMAAS_CLUSTER_SUBNET_PREFIX
 
+on_exit() {
+    # To troubleshoot a failed workflow either comment out `vm_cleanup` below or add `sleep 60m`
+    # to keep the virtual machines. For example:
+    # [[ $? -eq 0 ]] || sleep 60m
+    vm_copy_logs
+    vm_cleanup
+}
+
+trap on_exit EXIT
+
 vm_start
 vm_exec ./everything.sh
-
-RESULT=0
-if ! vm_exec ./test.sh; then
-  RESULT=1
-fi
-
-vm_copy_logs
-vm_cleanup
-
-exit $RESULT
+vm_exec ./test.sh

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -16,7 +16,6 @@ vm_exec ./everything.sh
 RESULT=0
 if ! vm_exec ./test.sh; then
   RESULT=1
-  sleep 60m
 fi
 
 vm_copy_logs

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -12,6 +12,13 @@ echo X1_NOMAAS_CLUSTER_SUBNET_PREFIX: $X1_NOMAAS_CLUSTER_SUBNET_PREFIX
 
 vm_start
 vm_exec ./everything.sh
-vm_exec ./test.sh
+
+RESULT=0
+if ! vm_exec ./test.sh; then
+  RESULT=1
+fi
+
+vm_copy_logs
 vm_cleanup
 
+exit $RESULT

--- a/scripts/jumphost/functions.sh
+++ b/scripts/jumphost/functions.sh
@@ -1,6 +1,6 @@
 # Functions used by other scripts
 
-: ${CONTROL_NODE_IMAGE:=pbchekin/icl-ccn-kubespray:0.0.3}
+: ${CONTROL_NODE_IMAGE:=pbchekin/icl-ccn-kubespray:0.0.4}
 : ${COREDNS_IMAGE:=registry.k8s.io/coredns/coredns:v1.8.6}
 : ${NGINX_IMAGE:=nginx:stable}
 : ${ARTIFACTS_DIR:=$HOME/generated}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 import pytest
@@ -184,8 +185,10 @@ def jupyterhub_enable_ssh(jupyterhub_namespace, jupyterhub_session_pod_name):
     )
 
     # output is "Use the following command to log in to your session: ssh jovyan@localtest.me -p 32001"
-    assert 'log in to your session' in output
+    cs_match = re.match(r'.+: ssh jovyan@([^ ]+) -p (\d+)', output)
+    assert cs_match, 'output matches'
 
-    # TODO: parse it from `output`?
-    port = 32001
-    yield username, password, port
+    host = cs_match.group(1)
+    port = int(cs_match.group(2))
+
+    yield username, password, host, port

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -184,12 +184,11 @@ def jupyterhub_enable_ssh(jupyterhub_namespace, jupyterhub_session_pod_name):
         ],
     )
 
-    print(f'output: "{output}"')
     # output is "Use the following command to log in to your session: ssh jovyan@localtest.me -p 32001"
-    cs_match = re.match(r'.+: ssh jovyan@([^ ]+) -p (\d+)', output)
-    assert cs_match, 'output matches'
+    matcher = re.search(r'.+: ssh jovyan@([^ ]+) -p (\d+)', output)
+    assert matcher, f'output "{output}" matches regex'
 
-    host = cs_match.group(1)
-    port = int(cs_match.group(2))
+    host = matcher.group(1)
+    port = int(matcher.group(2))
 
     yield username, password, host, port

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -184,6 +184,7 @@ def jupyterhub_enable_ssh(jupyterhub_namespace, jupyterhub_session_pod_name):
         ],
     )
 
+    print(f'output: "{output}"')
     # output is "Use the following command to log in to your session: ssh jovyan@localtest.me -p 32001"
     cs_match = re.match(r'.+: ssh jovyan@([^ ]+) -p (\d+)', output)
     assert cs_match, 'output matches'

--- a/tests/integration/test_infractl.py
+++ b/tests/integration/test_infractl.py
@@ -302,9 +302,9 @@ async def test_python_program(address, runtime_kind):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('kind', ['ssh'])
 async def test_python_program_ssh(address, kind, jupyterhub_enable_ssh):
-    username, password, port = jupyterhub_enable_ssh
+    username, password, host, port = jupyterhub_enable_ssh
     infrastructure = infractl.infrastructure(
-        address=address, username=username, password=password, port=port, kind=kind
+        address=host, username=username, password=password, port=port, kind=kind
     )
     runtime = infractl.runtime(kind=kind)
     program = infractl.program('flows/program1.py')

--- a/vagrant-rl-kind/Vagrantfile
+++ b/vagrant-rl-kind/Vagrantfile
@@ -9,9 +9,9 @@ Vagrant.configure(2) do |config|
   end
 
   libvirt_default_prefix = ENV.fetch("X1_LIBVIRT_DEFAULT_PREFIX", ENV.fetch('USER', "nouser"))
-  libvirt_memory = ENV.fetch("VM_MEMORY")
-  libvirt_cpus = ENV.fetch("VM_CPU").to_i
-  libvirt_machine_virtual_size = ENV.fetch("VM_DISK").to_i
+  libvirt_memory = ENV.fetch("VM_MEMORY", "16384")
+  libvirt_cpus = ENV.fetch("VM_CPU", "8").to_i
+  libvirt_machine_virtual_size = ENV.fetch("VM_DISK", "50").to_i
 
   config.vm.box = "rockylinux/9"
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -11,8 +11,8 @@ Vagrant.configure(2) do |config|
   end
 
   libvirt_default_prefix = ENV.fetch("X1_LIBVIRT_DEFAULT_PREFIX", ENV.fetch('USER', "nouser"))
-  libvirt_memory = ENV.fetch("VM_MEMORY")
-  libvirt_cpus = ENV.fetch("VM_CPU").to_i
+  libvirt_memory = ENV.fetch("VM_MEMORY", "16384")
+  libvirt_cpus = ENV.fetch("VM_CPU", "8").to_i
 
   cluster_vm_name_prefix = "cluster"
   cluster_size = 3


### PR DESCRIPTION
* Use Kubespray 2.24.1 (looks like there was a regression in 2.24.0).
* Fix logs collection in the workflow.
* Fix integration test for ssh: host name was hardcoded to localtest.me (jumphost), while in the case of multi-node cluster the ssh host name is returned dynamically.