### PR TITLE
Fix check if args to script are invalid

### DIFF
--- a/scripts/deploy/aws.sh
+++ b/scripts/deploy/aws.sh
@@ -111,6 +111,8 @@ function render_workspace() {
 
 # This script is designed to work in the project root
 cd "$PROJECT_ROOT"
+allowed=("--help" "--console" "--check" "--render" "--deploy-eks" "--deploy-x1" "--config" "--delete" "--delete-x1" "--delete-eks" "--start-proxy" "--stop-proxy")
+check_args $@ allowed 
 
 if [[ " $@ " =~ " --help " ]]; then
   show_help

--- a/scripts/deploy/aws.sh
+++ b/scripts/deploy/aws.sh
@@ -111,8 +111,8 @@ function render_workspace() {
 
 # This script is designed to work in the project root
 cd "$PROJECT_ROOT"
-allowed=("--help" "--console" "--check" "--render" "--deploy-eks" "--deploy-x1" "--config" "--delete" "--delete-x1" "--delete-eks" "--start-proxy" "--stop-proxy")
-check_args $@ allowed 
+allowed=(--help --console --check --render --deploy-eks --deploy-x1 --config --delete --delete-x1 --delete-eks --start-proxy --stop-proxy)
+check_args "$@"
 
 if [[ " $@ " =~ " --help " ]]; then
   show_help

--- a/scripts/deploy/functions.sh
+++ b/scripts/deploy/functions.sh
@@ -206,7 +206,7 @@ function check_args() {
   invalid_arg=false
 
   for arg in "$@"; do
-      if [ $arg = "--console" ]; then
+      if [[ $arg == "--console" ]]; then
         break  
       fi
       # Check if the argument is not in the allowed list

--- a/scripts/deploy/functions.sh
+++ b/scripts/deploy/functions.sh
@@ -201,6 +201,25 @@ function fail() {
   echo -e "${RED}[FAIL]${ENDCOLOR} $1"
 }
 
+function check_args(){
+  allowed=$2
+
+  # Flag to check if any invalid argument is found
+  invalid_arg=false
+
+  for arg in "$1"; do
+      # Check if the argument is not in the allowed list
+      if [[ ! " ${allowed[@]} " =~ " $arg " ]]; then
+          echo "Invalid argument: $arg"
+          invalid_arg=true
+      fi
+  done
+  if [ "$invalid_arg" = true ]; then
+      show_help
+      exit 1
+  fi
+}
+
 function is_installed() {
   local cmd="$1"
   if command -v "$cmd"  &> /dev/null; then

--- a/scripts/deploy/functions.sh
+++ b/scripts/deploy/functions.sh
@@ -201,20 +201,21 @@ function fail() {
   echo -e "${RED}[FAIL]${ENDCOLOR} $1"
 }
 
-function check_args(){
-  allowed=$2
-
+function check_args() {
   # Flag to check if any invalid argument is found
   invalid_arg=false
 
-  for arg in "$1"; do
+  for arg in "$@"; do
+      if [ $arg = "--console" ]; then
+        break  
+      fi
       # Check if the argument is not in the allowed list
       if [[ ! " ${allowed[@]} " =~ " $arg " ]]; then
           echo "Invalid argument: $arg"
           invalid_arg=true
       fi
   done
-  if [ "$invalid_arg" = true ]; then
+  if [ $invalid_arg == true ]; then
       show_help
       exit 1
   fi

--- a/scripts/deploy/gke.sh
+++ b/scripts/deploy/gke.sh
@@ -183,8 +183,8 @@ fi
 
 # This script is designed to work in the project root
 cd "$PROJECT_ROOT"
-allowed=("--help" "--console" "--check" "--render" "--deploy-gke" "--deploy-x1" "--config" "--delete" "--delete-x1" "--delete-gke" "--gcloud-login" "" "--start-proxy" "--stop-proxy")
-check_args $@ allowed 
+allowed=(--help --console --check --render --deploy-gke --deploy-x1 --config --delete --delete-x1 --delete-gke --gcloud-login  --start-proxy --stop-proxy)
+check_args "$@" 
 
 if [[ " $@ " =~ " --help " ]]; then
   show_help

--- a/scripts/deploy/gke.sh
+++ b/scripts/deploy/gke.sh
@@ -183,6 +183,8 @@ fi
 
 # This script is designed to work in the project root
 cd "$PROJECT_ROOT"
+allowed=("--help" "--console" "--check" "--render" "--deploy-gke" "--deploy-x1" "--config" "--delete" "--delete-x1" "--delete-gke" "--gcloud-login" "" "--start-proxy" "--stop-proxy")
+check_args $@ allowed 
 
 if [[ " $@ " =~ " --help " ]]; then
   show_help


### PR DESCRIPTION
Checks if arguments to aws.sh is invalid, this can save confusion using the script. 
eg
Running ./aws.sh --destroy instead of deleting would  just relaunch cluster causing confusion, this can be prevented by validating args. 